### PR TITLE
Fix cascade move legality

### DIFF
--- a/lib/freecell/card.rb
+++ b/lib/freecell/card.rb
@@ -20,9 +20,11 @@ module Freecell
       end
     end
 
-    def <=>(other)
-      rank <=> other.rank
+    def can_move_to?(other)
+      rank == other.rank - 1 && opposite_color?(other)
     end
+
+    private
 
     def opposite_color?(other)
       red = [:hearts, :diamonds]

--- a/lib/freecell/game_state.rb
+++ b/lib/freecell/game_state.rb
@@ -14,8 +14,7 @@ module Freecell
     end
 
     def apply(move)
-      type = move[0]
-      case type
+      case move[0]
       when :cascade_to_free_cell
         perform_cascade_to_freecell_move(move)
       when :cascade
@@ -60,7 +59,7 @@ module Freecell
       _, source, dest = move
       source_card = @cascades[source].last
       dest_card = @cascades[dest].last
-      source_card < dest_card && source_card.opposite_color?(dest_card)
+      source_card.can_move_to?(dest_card)
     end
   end
 end

--- a/lib/freecell/ncurses_ui.rb
+++ b/lib/freecell/ncurses_ui.rb
@@ -55,10 +55,22 @@ module Freecell
     end
 
     def render_cascades(game_state, start_y)
+      current_y = start_y
       game_state.printable_card_grid.each_with_index do |row, i|
         Curses.addstr(row.map(&:to_s).join('   '))
-        Curses.setpos(start_y + i, 0)
+        current_y = start_y + i
+        Curses.setpos(current_y, 0)
       end
+      Curses.setpos(current_y + 2, 0)
+      game_state.cascades.length.times do |i|
+        Curses.addstr(" #{i_to_cascade_letter(i)}    ")
+      end
+    end
+
+
+    def i_to_cascade_letter(i)
+      ascii_a = 97
+      [i + ascii_a].pack('c*')
     end
   end
 end


### PR DESCRIPTION
Can only move between cascades if the source card value is one less than
the dest card value, and if they are opposite colors.